### PR TITLE
Pinned Layers, fixes for PauseViewport, fixes for Hotkeys

### DIFF
--- a/DEV_RELEASE_NOTES.md
+++ b/DEV_RELEASE_NOTES.md
@@ -321,6 +321,9 @@ Unrpojected Images will always be square with a 1:1 Pixel Aspect Ratio.
 
 Tool Menu Entries were not deactivated when no project was open
 
+User-set Hotkeys for MARI Extension Pack Tools would get discarded after Mari closed.
+
+
 ######Pause Viewport Update
 
 The icon for 'Pause Viewport Update' would not be found on MARI Configurations with multiple Script Paths.

--- a/DEV_RELEASE_NOTES.md
+++ b/DEV_RELEASE_NOTES.md
@@ -325,6 +325,9 @@ Tool Menu Entries were not deactivated when no project was open
 
 The icon for 'Pause Viewport Update' would not be found on MARI Configurations with multiple Script Paths.
 
+It was possible for the Enabled/Disabled state of the Icon to fall out of sync with the Viewport when the action
+was triggered via scripts.
+
 
 ######Export Custom Channel Selection
 

--- a/DEV_RELEASE_NOTES.md
+++ b/DEV_RELEASE_NOTES.md
@@ -152,6 +152,33 @@ Currently only Face & Patch Selections are supported. Isolate Selection cannot b
 A new tool was added to the 'Selection Group' Palette that will allow you to easily create a materialID channel from your selection groups
 
 
+#####Layers:
+
+######Pinned Layers
+
+A bookmarking system for layer selections was implemented.
+Pinned Layers simplify the way of sharing a layer or group into a different channel or stack.
+Pinned Layers have two modes - Quick Pins & Collection Pin
+
+- Quick Pins:
+  Quick Pins can be used to quickly mark one or more layers for a sharing operation.
+  It works similar to a copy+paste operation but instead of pasting a duplicate of a layer, it creates
+  a shared layer of the original at your target location.
+  The same layer can be 'pasted' multiple times in different places.
+
+  A quick pin can be stored via the Option Layer/Pin/Save Quick Pin, then inserted into the stack by using the
+  Layer/Add Pinned Layer/Quick Pin option.
+  For convenience the default hotkeys CTRL+ALT+S and CTRL+ALT+V were set to save+insert a Quick Pin.
+
+- Collection Pins
+  Collection Pins are useful if you need to repeatedly have access to the same layers for sharing.
+  While Quick Pins work like a one time clipboard, Collection Pins allow you to pin layers or groups
+  to the Layer/Add Pinned Layer/ Menu for later access
+
+- Manage Collections
+  The Layer/Pin/Manage Collections options allows you to remove pinned collection layers from you pinned layers list.
+
+
 #####Objects:
 
 ######Export Object

--- a/DEV_RELEASE_NOTES.md
+++ b/DEV_RELEASE_NOTES.md
@@ -239,6 +239,10 @@ The 'Falloff Map' Node has been removed since it no longer serves any purpose.
 
 ###Tools:
 
+######General
+
+Extension Pack Tools are now grouped under a logical 'MARI Extension Pack' Group in the Hotkey Editor
+
 
 ######Export Custom Channel Selection
 
@@ -399,6 +403,13 @@ the path '/Filter/' in the CATEGORY section of the xml file
 
 This allows for placement of adjustment files in other locations as the
 Adjustment Layer Submenu.
+
+
+######New Action Paths
+
+Extension Pack Tool Actions have been moved out of /Mari/Scripts/ and into /Mari/MARI Extension Pack/.
+If you are using any Extension Pack Actions in your own scripts you need to update to the new path.
+
 
 ######New Functions
 

--- a/DEV_RELEASE_NOTES.md
+++ b/DEV_RELEASE_NOTES.md
@@ -313,6 +313,9 @@ Unrpojected Images will always be square with a 1:1 Pixel Aspect Ratio.
 
 ###Tools:
 
+######General
+
+Tool Menu Entries were not deactivated when no project was open
 
 ######Pause Viewport Update
 

--- a/Scripts/ExtensionPack_3v01/Tools/Layers/extPack_pinnedLayers.py
+++ b/Scripts/ExtensionPack_3v01/Tools/Layers/extPack_pinnedLayers.py
@@ -1,0 +1,181 @@
+# ------------------------------------------------------------------------------
+# Pinned Layers
+# ------------------------------------------------------------------------------
+# Allows the user to add a layer as a quick link for sharing to the ui
+# ------------------------------------------------------------------------------
+# Written by Jens Kafitz, 2015
+# ------------------------------------------------------------------------------
+# http://www.campi3d.com
+# ------------------------------------------------------------------------------
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF HE POSSIBILITY OF SUCH DAMAGE.
+# ------------------------------------------------------------------------------
+
+
+import mari
+
+# ------------------------------------------------------------------------------
+def returnTrue(layer):
+    """Returns True for any object passed to it."""
+    return True
+
+# ------------------------------------------------------------------------------
+def getLayerList(layer_list, criterionFn):
+    """Returns a list of all of the layers in the stack that match the given criterion function, including substacks."""
+    matching = []
+    for layer in layer_list:
+        if criterionFn(layer):
+            matching.append(layer)
+        if hasattr(layer, 'layerStack') is True and layer.isChannelLayer() is False:
+            matching.extend(getLayerList(layer.layerStack().layerList(), criterionFn))
+        if layer.hasMaskStack():
+            matching.extend(getLayerList(layer.maskStack().layerList(), criterionFn))
+        if hasattr(layer, 'hasAdjustmentStack') and layer.hasAdjustmentStack():
+            matching.extend(getLayerList(layer.adjustmentStack().layerList(), criterionFn))
+        if layer.isGroupLayer():
+            matching.extend(getLayerList(layer.layerStack().layerList(), criterionFn))
+
+    return matching
+# ------------------------------------------------------------------------------
+
+def findLayerUUID(UUID):
+    """Looks for a layer based on its uuid"""
+
+    curGeo = mari.geo.current()
+    channels = curGeo.channelList()
+    layerTarget = None
+
+    for channel in channels:
+
+        chn_layerList = channel.layerList()
+        layers = getLayerList(chn_layerList,returnTrue)
+
+        for layer in layers:
+            if layer.uuid() == UUID:
+                layerTarget = layer
+
+
+    return layerTarget
+
+
+def findLayerSelection():
+    """Searches for the current selection if mari.current.layer is not the same as layer.isSelected"""
+
+    curGeo = mari.geo.current()
+    curChannel = curGeo.currentChannel()
+    channels = curGeo.channelList()
+    curLayer = mari.current.layer()
+
+    layers = ()
+    layerSelList = []
+    chn_layerList = ()
+
+    layerSelect = False
+
+    if curLayer.isSelected():
+    # If current layer is indeed selected one just trawl through current channel to find others
+        layerSelect = True
+        chn_layerList = curChannel.layerList()
+        layers = getLayerList(chn_layerList,returnTrue)
+
+        for layer in layers:
+            if layer.isSelected():
+                layerSelList.append(layer)
+
+    else:
+    # If current layer is not selected it means that a selection sits somewhere else (non-current channel)
+    # so we are going trawling through the entire channel list including substacks to find it
+
+        for channel in channels:
+
+            chn_layerList = channel.layerList()
+            layers = getLayerList(chn_layerList,returnTrue)
+
+            for layer in layers:
+
+                if layer.isSelected():
+                    curLayer = layer
+                    curChannel = channel
+                    layerSelect = True
+                    layerSelList.append(layer)
+
+
+    if not layerSelect:
+        mari.utils.message('No Layer Selection found. \n \n Please select at least one Layer.')
+
+
+    return curGeo,curLayer,curChannel,layerSelList
+
+# ------------------------------------------------------------------------------
+
+def AddQuickPin():
+    """Adds a Layer to the Quick Pins"""
+
+    # Find selected layers
+    selection = findLayerSelection()
+    layerSelection = selection[3]
+    quickPinCount = 0 #Save the count at the end and read it out
+    projectUUID = str(mari.current.project().uuid())
+
+    UI_path = 'MainWindow/&Layers/' + u'Add Pinned Layer/Quick Pins'
+
+    for layer in layerSelection:
+
+        layerName = str(layer.name())
+        layerUUID = str(layer.uuid())
+
+        # Build the unique string for the layer identifier
+        LayerIDString = '"' + layerName +'"'+ ',' +'"' + projectUUID +'"'+ ',' +'"'+ layerUUID +'"'
+
+
+        layerAction = mari.actions.create(layerName,'mari.customScripts.triggerQuickPin(' + LayerIDString + ')' )
+        mari.menus.addAction(layerAction,UI_path)
+
+
+
+def triggerQuickPin(layerName,project_uuid,layer_uuid):
+    """Adds a shared layer from the Quick Pins and removes the Action associated with it later on"""
+
+    if project_uuid != mari.current.project().uuid():
+        mari.utils.message('This Layer does not belong to this project','Layer in different project')
+        return
+
+    # Find selected layers
+    selection = findLayerSelection()
+    curLayer = selection[1]
+    curChannel = selection[2]
+    layertoShare = findLayerUUID(layer_uuid)
+
+    if layertoShare is not None:
+        curChannel.shareLayer(layertoShare,curLayer)
+
+    else:
+        mari.utils.message('Could not find layer associated to Quick Pin: '+ layerName,'A problem occurred')
+
+    actionPath = '/Mari/Scripts/'+ str(layerName)
+    actionToRemove = mari.actions.find(actionPath)
+    quickPinPath = 'MainWindow/&Layers/' + u'Add Pinned Layer/Quick Pins'
+    mari.menus.removeAction(actionToRemove,quickPinPath)

--- a/Scripts/ExtensionPack_3v01/Tools/Shading/extPack_disableViewport.py
+++ b/Scripts/ExtensionPack_3v01/Tools/Shading/extPack_disableViewport.py
@@ -41,20 +41,48 @@ import mari
 
 
 def _isProjectSuitable():
-	if mari.projects.current() is None:
-		mari.utils.message("Please open a project before running.")
-		return False, False
+    if mari.projects.current() is None:
+        mari.utils.message("Please open a project before running.")
+        return False, False
 
-	else:
-		return True,True
+    else:
+        return True,True
 
 
-def disableViewport():
-	suitable = _isProjectSuitable()
-	if not suitable[0]:
-		action = mari.actions.find('/Mari/Scripts/Pause Viewport Update')
-		action.setChecked(False)
-		return
 
-	disableViewport = mari.actions.get('/Mari/Canvas/Toggle Shader Compiling')
-	disableViewport.trigger()
+def toggleViewport():
+    """Disables or enables Viewport"""
+
+    suitable = _isProjectSuitable()
+
+    action = mari.actions.find("/Mari/MARI Extension Pack/Shading/Pause Viewport Update")
+
+    if not suitable[0]:
+        action.setChecked(False)
+        return
+
+    if action.isChecked() is False:
+            mari.canvases.setPauseShaderCompiles(False)
+    else:
+            mari.canvases.setPauseShaderCompiles(True)
+
+
+def toggleDisableViewportIcon():
+    """This is triggered directly by the viewport signal to ensure icon state is always correct"""
+
+    iconAction = mari.actions.find('/Mari/MARI Extension Pack/Shading/Pause Viewport Update')
+    if iconAction.isChecked() is True:
+        iconAction.setChecked(False)
+    else:
+        iconAction.setChecked(True)
+
+
+def disableViewport(mode):
+    """Determine if only icon needs changing or full action"""
+
+    if mode == 'iconOnly':
+        toggleDisableViewportIcon()
+    else:
+        toggleViewport()
+
+

--- a/Scripts/ExtensionPack_3v01/Tools/__init__.py
+++ b/Scripts/ExtensionPack_3v01/Tools/__init__.py
@@ -61,6 +61,8 @@ import Layers.extPack_channel_layer as channel_layer
 import Layers.extPack_clone_merge_layers as clone_merge_layers
 import Layers.extPack_toggle_visibility_lock as toggle_layer_visibility_lock
 import Layers.extPack_convert_to_paintable as convert_to_paintable
+import Layers.extPack_pinnedLayers as pinned_layers
+
 
 # CHANNELS:
 import Channels.extPack_exportSelectedChannels as export_selected_channels
@@ -176,6 +178,13 @@ class customScripts():
 
     def convertToPaintable(self):
         convert_to_paintable.convertToPaintable()
+
+
+    def quickPin(self):
+        pinned_layers.AddQuickPin()
+
+    def triggerQuickPin(self,layerName,project_uuid,layer_uuid):
+        pinned_layers.triggerQuickPin(layerName,project_uuid,layer_uuid)
 
     # --------------------------------------------------------------
     # SHADERS:

--- a/Scripts/ExtensionPack_3v01/Tools/__init__.py
+++ b/Scripts/ExtensionPack_3v01/Tools/__init__.py
@@ -179,18 +179,22 @@ class customScripts():
     def convertToPaintable(self):
         convert_to_paintable.convertToPaintable()
 
+    # Pinned Layers:
 
-    # Pinned Layers
+    def emptyPin(self):
+        pinned_layers.emptyQuickPin()
 
     def quickPin(self):
-        pinned_layers.AddQuickPin()
+        pinned_layers.addQuickPin()
 
     def triggerQuickPin(self,layerName,project_uuid,layer_uuid):
         pinned_layers.triggerQuickPin(layerName,project_uuid,layer_uuid)
 
-    def emptyQuickPin(self):
-        pinned_layers.emptyQuickPin()
+    def collectionPin(self):
+        pinned_layers.addCollectionPin()
 
+    def triggerCollectionPin(self,layerName,project_uuid,layer_uuid):
+        pinned_layers.triggerCollectionPin(layerName,project_uuid,layer_uuid)
 
     # --------------------------------------------------------------
     # SHADERS:
@@ -298,7 +302,11 @@ print 'Channel Menu: Resize/Save Channel Resolution'
 print 'Channel Menu: Resize/Load Channel Resolution'
 print 'Channel Menu: Duplicate'
 print '-----------------------------------------'
-print 'Layer Palette Additions (7): '
+print 'Layer Palette Additions (11): '
+print 'Layer Menu: Add Pinned Layer'
+print 'Layer Menu: Pin/Save Quick Pin'
+print 'Layer Menu: Pin/Pin to Collection'
+print 'Layer Menu: Pin/Manage Collection Pins'
 print 'Layer Menu: Add Channel Layer'
 print 'Layer Menu: Layer Mask/Add Mask/Add Channel Mask'
 print 'Layer Menu: Layer Mask/Add Mask/Add Channel Mask (Group)'

--- a/Scripts/ExtensionPack_3v01/Tools/__init__.py
+++ b/Scripts/ExtensionPack_3v01/Tools/__init__.py
@@ -242,9 +242,8 @@ class customScripts():
     # --------------------------------------------------------------
     # SHADING:
 
-    def disableViewport(self):
-        disableViewport.disableViewport()
-
+    def disableViewport(self,mode):
+        disableViewport.disableViewport(mode)
 
     # --------------------------------------------------------------
     # HELP:

--- a/Scripts/ExtensionPack_3v01/Tools/__init__.py
+++ b/Scripts/ExtensionPack_3v01/Tools/__init__.py
@@ -180,11 +180,17 @@ class customScripts():
         convert_to_paintable.convertToPaintable()
 
 
+    # Pinned Layers
+
     def quickPin(self):
         pinned_layers.AddQuickPin()
 
     def triggerQuickPin(self,layerName,project_uuid,layer_uuid):
         pinned_layers.triggerQuickPin(layerName,project_uuid,layer_uuid)
+
+    def emptyQuickPin(self):
+        pinned_layers.emptyQuickPin()
+
 
     # --------------------------------------------------------------
     # SHADERS:

--- a/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
+++ b/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
@@ -441,11 +441,11 @@ def createToolsMenu():
 
     # Actions for Saving and managing pins
     quickPinLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Save Quick Pin', 'mari.customScripts.quickPin()')
-    pinCollectionLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pin to Collection', None)
+    pinCollectionLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pin to Collection', 'mari.customScripts.collectionPin()')
     manageCollections = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Clear Collection',None)
 
     # Actions for Adding pinned Layers
-    quickPinInsert = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pins/Quick Pin',None)
+    quickPinInsert = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pins/Quick Pin','mari.customScripts.emptyPin()')
     emptyCol = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pins/No Collection Pins',None)
 
 
@@ -459,9 +459,6 @@ def createToolsMenu():
     mari.menus.addAction(quickPinLayer,UI_path,'Cut')
     mari.menus.addAction(pinCollectionLayer,UI_path)
     mari.menus.addAction(manageCollections,UI_path)
-    mari.menus.addAction(quickPinInsert,UI_path)
-    mari.menus.addSeparator(UI_path,'Save Quick Pin')
-    mari.menus.removeAction(quickPinInsert,UI_path)
 
 
     icon_filename = 'Painting.png'

--- a/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
+++ b/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
@@ -81,7 +81,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/File'
     script_menu_path = 'MainWindow/Scripts/File'
 
-    setProjectPath = mari.actions.create ('Project Paths', 'mari.customScripts.set_project_paths()')
+    setProjectPath = mari.actions.create ('/Mari/MARI Extension Pack/File/Project Paths', 'mari.customScripts.set_project_paths()')
     mari.actions.addToSet('RequiresProject',setProjectPath)
 
     mari.menus.addAction(setProjectPath, UI_path, 'Settings')
@@ -104,7 +104,7 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Selection'
     context_path = 'Canvas/Context/Visibility'
 
-    isolateSelect = mari.actions.create('Isolate Selection', 'mari.customScripts.isolateSelect()')
+    isolateSelect = mari.actions.create('/Mari/MARI Extension Pack/Selection/Isolate Selection', 'mari.customScripts.isolateSelect()')
     mari.actions.addToSet('RequiresProject',isolateSelect)
     isolateSelect.setShortcut('Ctrl+1')
     mari.menus.addAction(isolateSelect, UI_path, 'Hide Unselected')
@@ -129,7 +129,7 @@ def createToolsMenu():
     context_path = 'MriGeoEntity/ItemContext/'  + u'Subdivision'
 
 
-    setAllToHighestSUBD = mari.actions.create('Set all to Highest Level', 'mari.customScripts.setAllSUBDToHigh()')
+    setAllToHighestSUBD = mari.actions.create('/Mari/MARI Extension Pack/Objects/Subdivision/Set all to Highest Level', 'mari.customScripts.setAllSUBDToHigh()')
     mari.actions.addToSet('RequiresProject',setAllToHighestSUBD)
     mari.menus.addAction(setAllToHighestSUBD, UI_path, 'Generate')
     mari.menus.addAction(setAllToHighestSUBD, context_path,'Generate')
@@ -139,7 +139,7 @@ def createToolsMenu():
     icon_path = mari.resources.path(mari.resources.ICONS) + os.sep +  icon_filename
     setAllToHighestSUBD.setIconPath(icon_path)
 
-    setAllToLowestSUBD = mari.actions.create('Set all to Lowest Level', 'mari.customScripts.setAllSUBDToLow()')
+    setAllToLowestSUBD = mari.actions.create('/Mari/MARI Extension Pack/Objects/Subdivision/Set all to Lowest Level', 'mari.customScripts.setAllSUBDToLow()')
     mari.actions.addToSet('RequiresProject',setAllToLowestSUBD)
     mari.menus.addAction(setAllToLowestSUBD, UI_path)
     mari.menus.addAction(setAllToLowestSUBD, context_path)
@@ -150,7 +150,7 @@ def createToolsMenu():
     setAllToLowestSUBD.setIconPath(icon_path)
 
 
-    setAllVisibleToHighestSUBD = mari.actions.create('Set all Visible to Highest Level', 'mari.customScripts.setVisibleSUBDToHigh()')
+    setAllVisibleToHighestSUBD = mari.actions.create('/Mari/MARI Extension Pack/Objects/Subdivision/Set all Visible to Highest Level', 'mari.customScripts.setVisibleSUBDToHigh()')
     mari.actions.addToSet('RequiresProject',setAllVisibleToHighestSUBD)
     mari.menus.addAction(setAllVisibleToHighestSUBD, UI_path)
     mari.menus.addAction(setAllVisibleToHighestSUBD, context_path)
@@ -160,7 +160,7 @@ def createToolsMenu():
     icon_path = mari.resources.path(mari.resources.ICONS) + os.sep +  icon_filename
     setAllVisibleToHighestSUBD.setIconPath(icon_path)
 
-    setAllVisibleToLowestSUBD = mari.actions.create('Set all Visible to Lowest Level', 'mari.customScripts.setVisibleSUBDToLow()')
+    setAllVisibleToLowestSUBD = mari.actions.create('/Mari/MARI Extension Pack/Objects/Subdivision/Set all Visible to Lowest Level', 'mari.customScripts.setVisibleSUBDToLow()')
     mari.actions.addToSet('RequiresProject',setAllVisibleToLowestSUBD)
     mari.menus.addAction(setAllVisibleToLowestSUBD, UI_path)
     mari.menus.addAction(setAllVisibleToLowestSUBD, context_path)
@@ -183,7 +183,7 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Objects'
     context_path = 'MriGeoEntity/ItemContext'
 
-    exportGeo = mari.actions.create ('Export Object', 'mari.customScripts.exportGeometry()')
+    exportGeo = mari.actions.create ('/Mari/MARI Extension Pack/Objects/Export Object', 'mari.customScripts.exportGeometry()')
     mari.actions.addToSet('RequiresProject',exportGeo)
     exportGeoLight = mari.actions.create ('Export Object', 'mari.customScripts.exportGeometryLight()')
     mari.actions.addToSet('RequiresProject',exportGeoLight)
@@ -204,7 +204,7 @@ def createToolsMenu():
     context_path = 'MriGeoEntity/ItemContext'
 
     # One launches full interface where you can select multiple objects, the other just works on current object
-    exportUVMask = mari.actions.create ('Export UV Mask', 'mari.customScripts.exportUVMasks()')
+    exportUVMask = mari.actions.create ('/Mari/MARI Extension Pack/Objects/Export UV Mask', 'mari.customScripts.exportUVMasks()')
     mari.actions.addToSet('RequiresProject',exportUVMask)
     exportUVMaskLight = mari.actions.create ('Export UV Mask', 'mari.customScripts.exportUVMasksLight()')
     mari.actions.addToSet('RequiresProject',exportUVMaskLight)
@@ -237,7 +237,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Channels'
     script_menu_path = 'MainWindow/Scripts/Channels'
 
-    DuplicateFlatten = mari.actions.create ('Duplicate && Flatten', 'mari.customScripts.flattenSelectedChannels()')
+    DuplicateFlatten = mari.actions.create ('/Mari/MARI Extension Pack/Channels/Duplicate && Flatten', 'mari.customScripts.flattenSelectedChannels()')
     mari.actions.addToSet('RequiresProject',DuplicateFlatten)
 
     mari.menus.addAction(DuplicateFlatten, UI_path, 'Flatten')
@@ -256,7 +256,7 @@ def createToolsMenu():
     UI_path_B = 'MainWindow/&Channels/Export'
     script_menu_path = 'MainWindow/Scripts/Channels/Export'
 
-    ExportSelectedFlattened = mari.actions.create ('Export Custom Channel Selection', 'mari.customScripts.exportSelectedChannelsFlattened()')
+    ExportSelectedFlattened = mari.actions.create ('/Mari/MARI Extension Pack/Channels/Export Custom Channel Selection', 'mari.customScripts.exportSelectedChannelsFlattened()')
     ExportSelected = mari.actions.create ('Export Custom Channel Selection', 'mari.customScripts.exportSelectedChannels()')
     mari.actions.addToSet('RequiresProject',ExportSelectedFlattened)
     mari.actions.addToSet('RequiresProject',ExportSelected)
@@ -277,7 +277,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Channels/Resize'
     script_menu_path = 'MainWindow/Scripts/Channels/Template'
 
-    getChannelTemplate = mari.actions.create ('Save Channel Resolution ', 'mari.customScripts.channel_template_get()')
+    getChannelTemplate = mari.actions.create ('/Mari/MARI Extension Pack/Channels/Resize/Save Channel Resolution ', 'mari.customScripts.channel_template_get()')
     mari.actions.addToSet('RequiresProject',getChannelTemplate)
 
     mari.menus.addAction(getChannelTemplate, UI_path)
@@ -294,7 +294,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Channels/Resize'
     script_menu_path = 'MainWindow/Scripts/Channels/Template'
 
-    setChannelTemplate = mari.actions.create ('Load Channel Resolution', 'mari.customScripts.channel_template_set()')
+    setChannelTemplate = mari.actions.create ('/Mari/MARI Extension Pack/Channels/Resize/Load Channel Resolution', 'mari.customScripts.channel_template_set()')
     mari.actions.addToSet('RequiresProject', setChannelTemplate)
 
 
@@ -315,7 +315,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Channels'
     script_menu_path = 'MainWindow/Scripts/Channels/Template'
 
-    newChannelFromTemplate = mari.actions.create ('Create Channel from Resolution', 'mari.customScripts.channel_template_create()')
+    newChannelFromTemplate = mari.actions.create ('/Mari/MARI Extension Pack/Channels/Resize/Create Channel from Resolution', 'mari.customScripts.channel_template_create()')
     mari.actions.addToSet('RequiresProject',newChannelFromTemplate)
 
 
@@ -333,7 +333,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Channels'
     script_menu_path = 'MainWindow/Scripts/Channels'
 
-    DuplicateChannel = mari.actions.create ('Duplicate', 'mari.customScripts.duplicate_channel()')
+    DuplicateChannel = mari.actions.create ('/Mari/MARI Extension Pack/Channels/Duplicate', 'mari.customScripts.duplicate_channel()')
     mari.actions.addToSet('RequiresProject',DuplicateChannel)
 
     mari.menus.addAction(DuplicateChannel, UI_path, 'Cut')
@@ -355,7 +355,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Layers'
     script_menu_path = 'MainWindow/Scripts/Layers'
 
-    chanLayer = mari.actions.create('Add Channel Layer', 'mari.customScripts.ChannelLayerUI_layer()')
+    chanLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Add Channel Layer', 'mari.customScripts.ChannelLayerUI_layer()')
     mari.actions.addToSet('RequiresProject',chanLayer)
 
     mari.menus.addAction(chanLayer, UI_path, 'Add Adjustment Layer')
@@ -373,7 +373,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Layers/'
     script_menu_path = 'MainWindow/Scripts/Layers'
 
-    MergeDuplicate = mari.actions.create('Clone && Merge Layers', 'mari.customScripts.CloneMerge()')
+    MergeDuplicate = mari.actions.create('/Mari/MARI Extension Pack/Layers/Clone && Merge Layers', 'mari.customScripts.CloneMerge()')
     mari.actions.addToSet('RequiresProject',MergeDuplicate)
 
     mari.menus.addAction(MergeDuplicate, UI_path,'Transfer')
@@ -399,7 +399,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Layers/'
     script_menu_path = 'MainWindow/Scripts/Layers'
 
-    BatchConvertToPaintable = mari.actions.create ('Convert To Paintable', 'mari.customScripts.convertToPaintable()')
+    BatchConvertToPaintable = mari.actions.create ('/Mari/MARI Extension Pack/Layers/Convert To Paintable', 'mari.customScripts.convertToPaintable()')
     mari.actions.addToSet('RequiresProject',BatchConvertToPaintable)
 
     mari.menus.addAction(BatchConvertToPaintable, UI_path,'Sharing')
@@ -470,7 +470,7 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Layers/' + u'Visibility + Lock'
 
 
-    toggleSelVisibility = mari.actions.create('Toggle Selected Visibility', 'mari.customScripts.toggleSelVisibility()')
+    toggleSelVisibility = mari.actions.create('/Mari/MARI Extension Pack/Layers/Visibility + Lock/Toggle Selected Visibility', 'mari.customScripts.toggleSelVisibility()')
     mari.actions.addToSet('RequiresProject',toggleSelVisibility)
 
     mari.menus.addAction(toggleSelVisibility, UI_path, 'Remove Layers')
@@ -481,7 +481,7 @@ def createToolsMenu():
     toggleSelVisibility.setIconPath(icon_path)
 
 
-    toggleUnselVisibility = mari.actions.create('Toggle Unselected Visibility', 'mari.customScripts.toggleUnselVisibility()')
+    toggleUnselVisibility = mari.actions.create('/Mari/MARI Extension Pack/Layers/Visibility + Lock/Toggle Unselected Visibility', 'mari.customScripts.toggleUnselVisibility()')
     mari.actions.addToSet('RequiresProject',toggleUnselVisibility)
 
     mari.menus.addAction(toggleUnselVisibility, UI_path)
@@ -500,7 +500,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Layers/' + u'Visibility + Lock'
     script_menu_path = 'MainWindow/Scripts/Layers/Visibility + Lock'
 
-    toggleSelLock = mari.actions.create('Toggle Selected Lock', 'mari.customScripts.toggleSelLock()')
+    toggleSelLock = mari.actions.create('/Mari/MARI Extension Pack/Layers/Visibility + Lock/Toggle Selected Lock', 'mari.customScripts.toggleSelLock()')
     mari.actions.addToSet('RequiresProject',toggleSelLock)
 
     mari.menus.addAction(toggleSelLock, UI_path)
@@ -511,7 +511,7 @@ def createToolsMenu():
     toggleSelLock.setIconPath(icon_path)
 
 
-    toggleUnselLock = mari.actions.create('Toggle Unselected Lock', 'mari.customScripts.toggleUnselLock()')
+    toggleUnselLock = mari.actions.create('/Mari/MARI Extension Pack/Layers/Visibility + Lock/Toggle Unselected Lock', 'mari.customScripts.toggleUnselLock()')
     mari.actions.addToSet('RequiresProject',toggleUnselLock)
 
     mari.menus.addAction(toggleUnselLock, UI_path)
@@ -537,7 +537,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Layers/Layer Mask/Add Mask'
     script_menu_path = 'MainWindow/Scripts/Layers/Layer Mask'
 
-    chanMask = mari.actions.create('Add Channel Mask', 'mari.customScripts.ChannelLayerUI_layermask()')
+    chanMask = mari.actions.create('/Mari/MARI Extension Pack/Layers/Add Mask/Add Channel Mask', 'mari.customScripts.ChannelLayerUI_layermask()')
     mari.actions.addToSet('RequiresProject',chanMask)
 
     mari.menus.addAction(chanMask, UI_path)
@@ -553,7 +553,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Layers/Layer Mask/Add Mask'
     script_menu_path = 'MainWindow/Scripts/Layers/Layer Mask'
 
-    chanMaskGrp = mari.actions.create('Add grouped Channel Mask', 'mari.customScripts.ChannelLayerUI_maskgroup()')
+    chanMaskGrp = mari.actions.create('/Mari/MARI Extension Pack/Layers/Add Mask/Add grouped Channel Mask', 'mari.customScripts.ChannelLayerUI_maskgroup()')
     mari.actions.addToSet('RequiresProject',chanMaskGrp)
 
     mari.menus.addAction(chanMaskGrp, UI_path)
@@ -575,7 +575,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Patches'
     script_menu_path = 'MainWindow/Scripts/Patches'
 
-    PatchToImageMgr= mari.actions.create('Patch to Image Manager', 'mari.customScripts.patch_bake_to_imageman()')
+    PatchToImageMgr= mari.actions.create('/Mari/MARI Extension Pack/Patches/Patch to Image Manager', 'mari.customScripts.patch_bake_to_imageman()')
     mari.actions.addToSet('RequiresProject',PatchToImageMgr)
 
     mari.menus.addAction(PatchToImageMgr, UI_path,'UV Mask to Image Manager')
@@ -605,7 +605,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Camera'
     script_menu_path = 'MainWindow/Scripts/Camera'
 
-    ChannelToImageMgr = mari.actions.create('Quick Unproject Channel', 'mari.customScripts.unproject_channel_to_imageman()')
+    ChannelToImageMgr = mari.actions.create('/Mari/MARI Extension Pack/Camera/Quick Unproject Channel', 'mari.customScripts.unproject_channel_to_imageman()')
     mari.actions.addToSet('RequiresProject',ChannelToImageMgr)
 
     mari.menus.addAction(ChannelToImageMgr, script_menu_path)
@@ -623,7 +623,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/&Camera'
     script_menu_path = 'MainWindow/Scripts/Camera'
 
-    LayerToImageMgr = mari.actions.create('Quick Unproject Layer', 'mari.customScripts.unproject_layer_to_imageman()')
+    LayerToImageMgr = mari.actions.create('/Mari/MARI Extension Pack/Camera/Quick Unproject Layer', 'mari.customScripts.unproject_layer_to_imageman()')
     mari.actions.addToSet('RequiresProject',LayerToImageMgr)
 
     mari.menus.addAction(LayerToImageMgr, UI_path,'Camera Left')
@@ -653,7 +653,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/View'
     script_menu_path = 'MainWindow/Scripts/View'
 
-    screenshotChannels = mari.actions.create('Screenshot All Channels','mari.customScripts.screenshot_all_channels()')
+    screenshotChannels = mari.actions.create('/Mari/MARI Extension Pack/View/Screenshot All Channels','mari.customScripts.screenshot_all_channels()')
     mari.actions.addToSet('RequiresProject',screenshotChannels)
 
     mari.menus.addAction(screenshotChannels, UI_path, 'Screenshot Settings')
@@ -673,7 +673,7 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Shading'
     UI_path = 'MainWindow/&Shading'
 
-    action_viewportDisable = mari.actions.create("Pause Viewport Update", "mari.customScripts.disableViewport()")
+    action_viewportDisable = mari.actions.create("/Mari/MARI Extension Pack/Shading/Pause Viewport Update", "mari.customScripts.disableViewport()")
     action_viewportDisable.setCheckable(True)
     mari.actions.addToSet('RequiresProject',action_viewportDisable)
 
@@ -716,7 +716,7 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Shaders'
 
     syncObjectShaders = mari.actions.create(
-        "Sync Object Shaders", "mari.customScripts.setAllObjectsToShader()"
+        "/Mari/MARI Extension Pack/Shaders Palette/Sync Object Shaders", "mari.customScripts.setAllObjectsToShader()"
         )
 
     mari.actions.addToSet('RequiresProject',syncObjectShaders)
@@ -744,7 +744,7 @@ def createToolsMenu():
     UI_path_B = 'MriGeometrySelectionGroup/Panel'
     script_menu_path = 'MainWindow/Scripts/Selection Groups'
 
-    matIdFromGroup = mari.actions.create("MaterialID from Selection Groups", "mari.customScripts.matIDFromGroup()")
+    matIdFromGroup = mari.actions.create("/Mari/MARI Extension Pack/Shaders Palette/MaterialID from Selection Groups", "mari.customScripts.matIDFromGroup()")
     mari.actions.addToSet('RequiresProject',matIdFromGroup)
 
 
@@ -769,7 +769,7 @@ def createToolsMenu():
     UI_path = 'MriImageManager/ItemContext'
     script_menu_path = 'MainWindow/Scripts/Image Manager'
 
-    exportImageMan = mari.actions.create ('Export Selection', 'mari.customScripts.exportImageManager()')
+    exportImageMan = mari.actions.create ('/Mari/MARI Extension Pack/Image Manager/Export Selection', 'mari.customScripts.exportImageManager()')
     mari.actions.addToSet('RequiresProject',exportImageMan)
 
     mari.menus.addAction(exportImageMan, UI_path)
@@ -794,7 +794,7 @@ def createToolsMenu():
     UI_path = 'MainWindow/Help'
     script_menu_path = 'MainWindow/Scripts/Help'
 
-    extHelp = mari.actions.create('Extension Pack Online Help','mari.customScripts.open_online_help()')
+    extHelp = mari.actions.create('/Mari/MARI Extension Pack/Help/Extension Pack Online Help','mari.customScripts.open_online_help()')
     mari.menus.addAction(extHelp, UI_path, 'Release Notes')
     mari.menus.addAction(extHelp, script_menu_path)
 

--- a/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
+++ b/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
@@ -423,15 +423,18 @@ def createToolsMenu():
 
     UI_path = 'MainWindow/&Layers/' + u'Pin'
 
-    quickPinLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Quick Pin Layer', 'mari.customScripts.quickPin()')
-    pinLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pin Layer to Collection', None)
+    quickPinLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Quick Pin', 'mari.customScripts.quickPin()')
+    pinLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pin to Collection', None)
     manageCollections = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Clear Collection',None)
-    emptyQuick = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/No Quick Pins',None)
+
+    emptyQuick = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Quick Pin (empty)',None)
     emptyCol = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/No Collection Pins',None)
 
     mari.actions.addToSet('RequiresProject',quickPinLayer)
     mari.actions.addToSet('RequiresProject',pinLayer)
     mari.actions.addToSet('RequiresProject',manageCollections)
+    mari.actions.addToSet('RequiresProject',emptyQuick)
+    mari.actions.addToSet('RequiresProject',emptyCol)
 
 
     # mari.menus.addSeparator(UI_path,'Remove Layers')
@@ -440,7 +443,7 @@ def createToolsMenu():
     mari.menus.addAction(pinLayer,UI_path)
     mari.menus.addAction(manageCollections,UI_path)
     mari.menus.addAction(emptyQuick,UI_path)
-    mari.menus.addSeparator(UI_path,'No Quick Pins')
+    mari.menus.addSeparator(UI_path,'Quick Pin (empty)')
     mari.menus.removeAction(emptyQuick,UI_path)
 
 
@@ -673,7 +676,7 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Shading'
     UI_path = 'MainWindow/&Shading'
 
-    action_viewportDisable = mari.actions.create("/Mari/MARI Extension Pack/Shading/Pause Viewport Update", "mari.customScripts.disableViewport()")
+    action_viewportDisable = mari.actions.create("/Mari/MARI Extension Pack/Shading/Pause Viewport Update", "mari.customScripts.disableViewport('full')")
     action_viewportDisable.setCheckable(True)
     mari.actions.addToSet('RequiresProject',action_viewportDisable)
 
@@ -691,13 +694,17 @@ def createToolsMenu():
     action_viewportDisable.setToolTip('Pause Viewport Update')
     action_viewportDisable.setWhatsThis('Pause Viewport Update. A repackaged toggleShaderCompile action')
 
-
     # Adding to default lighting toolbar
     lightingToolbar = mari.app.findToolBar('Lighting')
     isLocked = lightingToolbar.isLocked()
     lightingToolbar.setLocked(False)
-    lightingToolbar.addAction('/Mari/Scripts/Pause Viewport Update', [0,0], False)
+    lightingToolbar.addAction('/Mari/MARI Extension Pack/Shading/Pause Viewport Update', [0,0], False)
     lightingToolbar.setLocked(isLocked)
+
+    # Hooking up a signal directly to the viewport
+    toggleCompileAction = mari.actions.get('/Mari/Canvas/Toggle Shader Compiling')
+    mari.utils.connect(toggleCompileAction.triggered,lambda: mari.customScripts.disableViewport('iconOnly'))
+
 
     ###  Menu Separators ###
 

--- a/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
+++ b/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
@@ -48,13 +48,14 @@ CHANNELS,LAYERS,PATCHES etc.
 Items are placed within existing Menus (UI_Path) and a copy is placed
 in a common Script Menu (script_menu_path)
 
-Shortcut Bindings are available but not necessarily set.'''
+
+Please note that Shortcuts should NOT be set as part of the action creation
+Shortcuts are defined in bulk at the very end of the function by passing the shortcut
+to set and the action path to a shortcut check function that ensures that User
+set shortcuts are respected'''
 
 
 # --------------------------------------------------------------------
-
-
-
 
 
 import mari
@@ -62,14 +63,30 @@ import os
 
 tool_menu_version = '3.0'
 
-
 # Icon Path for custom icons
 extPack_icon_path = os.path.join(os.path.dirname(__file__), "Icons")
 
 
+
+def setShortCutifEmpty(shortcut,actionpath):
+    ''' Checks if User assigned Shortcut or shortcut clash exists'''
+
+    try:
+        # if a shortcut exists this won't error
+        mari.actions.shortcut(actionpath)
+        shortcutIsSet = True
+    except Exception:
+        shortcutIsSet = False
+        pass
+
+    if shortcutIsSet == False and mari.actions.shortcutIsInUse(shortcut) == False:
+        action = mari.actions.get(actionpath)
+        action.setShortcut(shortcut)
+
+
+
 def createToolsMenu():
-
-
+    '''Adds all Extension Pack Elements to UI'''
 
 ######################################################################
 # FILE
@@ -106,7 +123,7 @@ def createToolsMenu():
 
     isolateSelect = mari.actions.create('/Mari/MARI Extension Pack/Selection/Isolate Selection', 'mari.customScripts.isolateSelect()')
     mari.actions.addToSet('RequiresProject',isolateSelect)
-    isolateSelect.setShortcut('Ctrl+1')
+
     mari.menus.addAction(isolateSelect, UI_path, 'Hide Unselected')
     mari.menus.addAction(isolateSelect, context_path,'Hide Unselected')
     mari.menus.addAction(isolateSelect, script_menu_path)
@@ -382,7 +399,6 @@ def createToolsMenu():
     icon_filename = 'AddChannel.png'
     icon_path = mari.resources.path(mari.resources.ICONS) + os.sep +  icon_filename
     MergeDuplicate.setIconPath(icon_path)
-    MergeDuplicate.setShortcut('Ctrl+Shift+E')
 
 
     # --------------------------------------------------------------------
@@ -423,44 +439,44 @@ def createToolsMenu():
 
     UI_path = 'MainWindow/&Layers/' + u'Pin'
 
-    quickPinLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Quick Pin', 'mari.customScripts.quickPin()')
-    pinLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pin to Collection', None)
+    # Actions for Saving and managing pins
+    quickPinLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Save Quick Pin', 'mari.customScripts.quickPin()')
+    pinCollectionLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pin to Collection', None)
     manageCollections = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Clear Collection',None)
 
-    emptyQuick = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Quick Pin (empty)',None)
-    emptyCol = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/No Collection Pins',None)
+    # Actions for Adding pinned Layers
+    quickPinInsert = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pins/Quick Pin',None)
+    emptyCol = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pins/No Collection Pins',None)
+
 
     mari.actions.addToSet('RequiresProject',quickPinLayer)
-    mari.actions.addToSet('RequiresProject',pinLayer)
+    mari.actions.addToSet('RequiresProject',pinCollectionLayer)
     mari.actions.addToSet('RequiresProject',manageCollections)
-    mari.actions.addToSet('RequiresProject',emptyQuick)
+    mari.actions.addToSet('RequiresProject',quickPinInsert)
     mari.actions.addToSet('RequiresProject',emptyCol)
 
 
-    # mari.menus.addSeparator(UI_path,'Remove Layers')
-
     mari.menus.addAction(quickPinLayer,UI_path,'Cut')
-    mari.menus.addAction(pinLayer,UI_path)
+    mari.menus.addAction(pinCollectionLayer,UI_path)
     mari.menus.addAction(manageCollections,UI_path)
-    mari.menus.addAction(emptyQuick,UI_path)
-    mari.menus.addSeparator(UI_path,'Quick Pin (empty)')
-    mari.menus.removeAction(emptyQuick,UI_path)
+    mari.menus.addAction(quickPinInsert,UI_path)
+    mari.menus.addSeparator(UI_path,'Save Quick Pin')
+    mari.menus.removeAction(quickPinInsert,UI_path)
 
 
     icon_filename = 'Painting.png'
     icon_path = mari.resources.path(mari.resources.ICONS) + os.sep +  icon_filename
     quickPinLayer.setIconPath(icon_path)
-    pinLayer.setIconPath(icon_path)
+    pinCollectionLayer.setIconPath(icon_path)
 
     icon_filename = 'Folder.png'
     icon_path = mari.resources.path(mari.resources.ICONS) + os.sep +  icon_filename
     manageCollections.setIconPath(icon_path)
 
     UI_path = 'MainWindow/&Layers/' + u'Add Pinned Layer'
-    mari.menus.addAction(emptyQuick,UI_path,'Add Adjustment Layer')
+    mari.menus.addAction(quickPinInsert,UI_path,'Add Adjustment Layer')
     mari.menus.addSeparator(UI_path)
     mari.menus.addAction(emptyCol,UI_path)
-
 
 
 
@@ -687,7 +703,6 @@ def createToolsMenu():
     icon_filename = 'extPack_disableViewport.png'
     icon_path = extPack_icon_path + os.sep +  icon_filename
     action_viewportDisable.setIconPath(icon_path)
-    action_viewportDisable.setShortcut('Ctrl+Space')
 
 
     action_viewportDisable.setStatusTip('Pause Viewport Update. This can help speed up operations by not having to wait for the viewport to update.')
@@ -815,7 +830,6 @@ def createToolsMenu():
 
 
 
-
 ######################################################################
 # DISABLE ELEMENTS WHEN NO PROJECT IS OPEN
 ######################################################################
@@ -828,3 +842,29 @@ def createToolsMenu():
 
     mari.utils.connect(mari.projects.opened, lambda: mari.actions.enableSet('RequiresProject'))
     mari.utils.connect(mari.projects.closed, lambda: mari.actions.disableSet('RequiresProject'))
+
+
+
+######################################################################
+# LOAD USER SHORTCUTS OVERWRITING ANY DEFAULT ONES FOR EXT PACK ACTIONS
+######################################################################
+
+    mari.actions.loadUserShortcuts()
+
+    setShortCutifEmpty('Ctrl+1','/Mari/MARI Extension Pack/Selection/Isolate Selection')
+    setShortCutifEmpty('Ctrl+Shift+E','/Mari/MARI Extension Pack/Layers/Clone && Merge Layers')
+    setShortCutifEmpty('Ctrl+Alt+C','/Mari/MARI Extension Pack/Layers/Pin Layers/Save Quick Pin')
+    setShortCutifEmpty('Ctrl+Alt+V','/Mari/MARI Extension Pack/Layers/Pin Layers/Pins/Quick Pin')
+    setShortCutifEmpty('Ctrl+Space',"/Mari/MARI Extension Pack/Shading/Pause Viewport Update")
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
+++ b/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
@@ -82,6 +82,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/File'
 
     setProjectPath = mari.actions.create ('Project Paths', 'mari.customScripts.set_project_paths()')
+    mari.actions.addToSet('RequiresProject',setProjectPath)
+
     mari.menus.addAction(setProjectPath, UI_path, 'Settings')
     mari.menus.addAction(setProjectPath, script_menu_path)
 
@@ -103,6 +105,7 @@ def createToolsMenu():
     context_path = 'Canvas/Context/Visibility'
 
     isolateSelect = mari.actions.create('Isolate Selection', 'mari.customScripts.isolateSelect()')
+    mari.actions.addToSet('RequiresProject',isolateSelect)
     isolateSelect.setShortcut('Ctrl+1')
     mari.menus.addAction(isolateSelect, UI_path, 'Hide Unselected')
     mari.menus.addAction(isolateSelect, context_path,'Hide Unselected')
@@ -127,6 +130,7 @@ def createToolsMenu():
 
 
     setAllToHighestSUBD = mari.actions.create('Set all to Highest Level', 'mari.customScripts.setAllSUBDToHigh()')
+    mari.actions.addToSet('RequiresProject',setAllToHighestSUBD)
     mari.menus.addAction(setAllToHighestSUBD, UI_path, 'Generate')
     mari.menus.addAction(setAllToHighestSUBD, context_path,'Generate')
     mari.menus.addAction(setAllToHighestSUBD, script_menu_path)
@@ -136,6 +140,7 @@ def createToolsMenu():
     setAllToHighestSUBD.setIconPath(icon_path)
 
     setAllToLowestSUBD = mari.actions.create('Set all to Lowest Level', 'mari.customScripts.setAllSUBDToLow()')
+    mari.actions.addToSet('RequiresProject',setAllToLowestSUBD)
     mari.menus.addAction(setAllToLowestSUBD, UI_path)
     mari.menus.addAction(setAllToLowestSUBD, context_path)
     mari.menus.addAction(setAllToLowestSUBD, script_menu_path)
@@ -146,6 +151,7 @@ def createToolsMenu():
 
 
     setAllVisibleToHighestSUBD = mari.actions.create('Set all Visible to Highest Level', 'mari.customScripts.setVisibleSUBDToHigh()')
+    mari.actions.addToSet('RequiresProject',setAllVisibleToHighestSUBD)
     mari.menus.addAction(setAllVisibleToHighestSUBD, UI_path)
     mari.menus.addAction(setAllVisibleToHighestSUBD, context_path)
     mari.menus.addAction(setAllVisibleToHighestSUBD, script_menu_path)
@@ -155,6 +161,7 @@ def createToolsMenu():
     setAllVisibleToHighestSUBD.setIconPath(icon_path)
 
     setAllVisibleToLowestSUBD = mari.actions.create('Set all Visible to Lowest Level', 'mari.customScripts.setVisibleSUBDToLow()')
+    mari.actions.addToSet('RequiresProject',setAllVisibleToLowestSUBD)
     mari.menus.addAction(setAllVisibleToLowestSUBD, UI_path)
     mari.menus.addAction(setAllVisibleToLowestSUBD, context_path)
     mari.menus.addAction(setAllVisibleToLowestSUBD, script_menu_path)
@@ -177,7 +184,9 @@ def createToolsMenu():
     context_path = 'MriGeoEntity/ItemContext'
 
     exportGeo = mari.actions.create ('Export Object', 'mari.customScripts.exportGeometry()')
+    mari.actions.addToSet('RequiresProject',exportGeo)
     exportGeoLight = mari.actions.create ('Export Object', 'mari.customScripts.exportGeometryLight()')
+    mari.actions.addToSet('RequiresProject',exportGeoLight)
     mari.menus.addAction(exportGeo, UI_path, 'Ambient Occlusion')
     mari.menus.addAction(exportGeoLight, context_path,'Remove Object')
     mari.menus.addAction(exportGeo, script_menu_path)
@@ -196,7 +205,10 @@ def createToolsMenu():
 
     # One launches full interface where you can select multiple objects, the other just works on current object
     exportUVMask = mari.actions.create ('Export UV Mask', 'mari.customScripts.exportUVMasks()')
+    mari.actions.addToSet('RequiresProject',exportUVMask)
     exportUVMaskLight = mari.actions.create ('Export UV Mask', 'mari.customScripts.exportUVMasksLight()')
+    mari.actions.addToSet('RequiresProject',exportUVMaskLight)
+
 
     mari.menus.addAction(exportUVMask, UI_path, 'Ambient Occlusion')
     mari.menus.addAction(exportUVMaskLight, context_path,'Ambient Occlusion')
@@ -226,6 +238,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Channels'
 
     DuplicateFlatten = mari.actions.create ('Duplicate && Flatten', 'mari.customScripts.flattenSelectedChannels()')
+    mari.actions.addToSet('RequiresProject',DuplicateFlatten)
+
     mari.menus.addAction(DuplicateFlatten, UI_path, 'Flatten')
     mari.menus.addAction(DuplicateFlatten, script_menu_path)
 
@@ -244,6 +258,9 @@ def createToolsMenu():
 
     ExportSelectedFlattened = mari.actions.create ('Export Custom Channel Selection', 'mari.customScripts.exportSelectedChannelsFlattened()')
     ExportSelected = mari.actions.create ('Export Custom Channel Selection', 'mari.customScripts.exportSelectedChannels()')
+    mari.actions.addToSet('RequiresProject',ExportSelectedFlattened)
+    mari.actions.addToSet('RequiresProject',ExportSelected)
+
 
     mari.menus.addAction(ExportSelectedFlattened, UI_path_A,'Export Current Channel Flattened')
     mari.menus.addAction(ExportSelected, UI_path_B,'Export Current Channel')
@@ -261,6 +278,7 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Channels/Template'
 
     getChannelTemplate = mari.actions.create ('Save Channel Resolution ', 'mari.customScripts.channel_template_get()')
+    mari.actions.addToSet('RequiresProject',getChannelTemplate)
 
     mari.menus.addAction(getChannelTemplate, UI_path)
     mari.menus.addAction(getChannelTemplate, script_menu_path)
@@ -277,6 +295,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Channels/Template'
 
     setChannelTemplate = mari.actions.create ('Load Channel Resolution', 'mari.customScripts.channel_template_set()')
+    mari.actions.addToSet('RequiresProject', setChannelTemplate)
+
 
     mari.menus.addAction(setChannelTemplate, UI_path)
     mari.menus.addAction(setChannelTemplate, script_menu_path)
@@ -296,6 +316,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Channels/Template'
 
     newChannelFromTemplate = mari.actions.create ('Create Channel from Resolution', 'mari.customScripts.channel_template_create()')
+    mari.actions.addToSet('RequiresProject',newChannelFromTemplate)
+
 
     # mari.menus.addAction(newChannelFromTemplate, UI_path)
     mari.menus.addAction(newChannelFromTemplate, script_menu_path)
@@ -312,6 +334,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Channels'
 
     DuplicateChannel = mari.actions.create ('Duplicate', 'mari.customScripts.duplicate_channel()')
+    mari.actions.addToSet('RequiresProject',DuplicateChannel)
+
     mari.menus.addAction(DuplicateChannel, UI_path, 'Cut')
     mari.menus.addAction(DuplicateChannel, script_menu_path)
 
@@ -332,6 +356,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Layers'
 
     chanLayer = mari.actions.create('Add Channel Layer', 'mari.customScripts.ChannelLayerUI_layer()')
+    mari.actions.addToSet('RequiresProject',chanLayer)
+
     mari.menus.addAction(chanLayer, UI_path, 'Add Adjustment Layer')
     mari.menus.addAction(chanLayer, script_menu_path)
 
@@ -348,6 +374,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Layers'
 
     MergeDuplicate = mari.actions.create('Clone && Merge Layers', 'mari.customScripts.CloneMerge()')
+    mari.actions.addToSet('RequiresProject',MergeDuplicate)
+
     mari.menus.addAction(MergeDuplicate, UI_path,'Transfer')
     mari.menus.addAction(MergeDuplicate, script_menu_path)
 
@@ -372,6 +400,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Layers'
 
     BatchConvertToPaintable = mari.actions.create ('Convert To Paintable', 'mari.customScripts.convertToPaintable()')
+    mari.actions.addToSet('RequiresProject',BatchConvertToPaintable)
+
     mari.menus.addAction(BatchConvertToPaintable, UI_path,'Sharing')
     mari.menus.addAction(BatchConvertToPaintable, script_menu_path)
 
@@ -393,19 +423,25 @@ def createToolsMenu():
 
     UI_path = 'MainWindow/&Layers/' + u'Pin'
 
-    quickPinLayer = mari.actions.create('Quick Pin Layer(s)', 'mari.customScripts.quickPin()')
-    pinLayer = mari.actions.create('Pin Layer(s) to Collection', None)
-    manageCollections = mari.actions.create('Manage Collections',None)
-    empty = mari.actions.create('Do nothing',None)
+    quickPinLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Quick Pin Layer', 'mari.customScripts.quickPin()')
+    pinLayer = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Pin Layer to Collection', None)
+    manageCollections = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/Clear Collection',None)
+    emptyQuick = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/No Quick Pins',None)
+    emptyCol = mari.actions.create('/Mari/MARI Extension Pack/Layers/Pin Layers/No Collection Pins',None)
+
+    mari.actions.addToSet('RequiresProject',quickPinLayer)
+    mari.actions.addToSet('RequiresProject',pinLayer)
+    mari.actions.addToSet('RequiresProject',manageCollections)
+
 
     # mari.menus.addSeparator(UI_path,'Remove Layers')
 
     mari.menus.addAction(quickPinLayer,UI_path,'Cut')
     mari.menus.addAction(pinLayer,UI_path)
     mari.menus.addAction(manageCollections,UI_path)
-    mari.menus.addAction(empty,UI_path)
-    mari.menus.addSeparator(UI_path,'Do nothing')
-    mari.menus.removeAction(empty,UI_path)
+    mari.menus.addAction(emptyQuick,UI_path)
+    mari.menus.addSeparator(UI_path,'No Quick Pins')
+    mari.menus.removeAction(emptyQuick,UI_path)
 
 
     icon_filename = 'Painting.png'
@@ -418,11 +454,10 @@ def createToolsMenu():
     manageCollections.setIconPath(icon_path)
 
     UI_path = 'MainWindow/&Layers/' + u'Add Pinned Layer'
-    emptyQuick = mari.actions.create('No Layer pinned',None)
-    mari.menus.addAction(empty,UI_path,'Add Adjustment Layer')
-    UI_path_quick = 'MainWindow/&Layers/' + u'Add Pinned Layer/Quick Pins'
-    mari.menus.addAction(emptyQuick,UI_path_quick)
-    mari.menus.removeAction(empty,UI_path)
+    mari.menus.addAction(emptyQuick,UI_path,'Add Adjustment Layer')
+    mari.menus.addSeparator(UI_path)
+    mari.menus.addAction(emptyCol,UI_path)
+
 
 
 
@@ -436,6 +471,8 @@ def createToolsMenu():
 
 
     toggleSelVisibility = mari.actions.create('Toggle Selected Visibility', 'mari.customScripts.toggleSelVisibility()')
+    mari.actions.addToSet('RequiresProject',toggleSelVisibility)
+
     mari.menus.addAction(toggleSelVisibility, UI_path, 'Remove Layers')
     mari.menus.addAction(toggleSelVisibility, script_menu_path)
 
@@ -445,6 +482,8 @@ def createToolsMenu():
 
 
     toggleUnselVisibility = mari.actions.create('Toggle Unselected Visibility', 'mari.customScripts.toggleUnselVisibility()')
+    mari.actions.addToSet('RequiresProject',toggleUnselVisibility)
+
     mari.menus.addAction(toggleUnselVisibility, UI_path)
     mari.menus.addAction(toggleUnselVisibility, script_menu_path)
 
@@ -462,6 +501,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Layers/Visibility + Lock'
 
     toggleSelLock = mari.actions.create('Toggle Selected Lock', 'mari.customScripts.toggleSelLock()')
+    mari.actions.addToSet('RequiresProject',toggleSelLock)
+
     mari.menus.addAction(toggleSelLock, UI_path)
     mari.menus.addAction(toggleSelLock, script_menu_path)
 
@@ -471,6 +512,8 @@ def createToolsMenu():
 
 
     toggleUnselLock = mari.actions.create('Toggle Unselected Lock', 'mari.customScripts.toggleUnselLock()')
+    mari.actions.addToSet('RequiresProject',toggleUnselLock)
+
     mari.menus.addAction(toggleUnselLock, UI_path)
     mari.menus.addAction(toggleUnselLock, script_menu_path)
 
@@ -495,6 +538,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Layers/Layer Mask'
 
     chanMask = mari.actions.create('Add Channel Mask', 'mari.customScripts.ChannelLayerUI_layermask()')
+    mari.actions.addToSet('RequiresProject',chanMask)
+
     mari.menus.addAction(chanMask, UI_path)
     mari.menus.addAction(chanMask, script_menu_path)
 
@@ -509,6 +554,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Layers/Layer Mask'
 
     chanMaskGrp = mari.actions.create('Add grouped Channel Mask', 'mari.customScripts.ChannelLayerUI_maskgroup()')
+    mari.actions.addToSet('RequiresProject',chanMaskGrp)
+
     mari.menus.addAction(chanMaskGrp, UI_path)
     mari.menus.addAction(chanMaskGrp, script_menu_path)
 
@@ -529,6 +576,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Patches'
 
     PatchToImageMgr= mari.actions.create('Patch to Image Manager', 'mari.customScripts.patch_bake_to_imageman()')
+    mari.actions.addToSet('RequiresProject',PatchToImageMgr)
+
     mari.menus.addAction(PatchToImageMgr, UI_path,'UV Mask to Image Manager')
     mari.menus.addAction(PatchToImageMgr, script_menu_path)
 
@@ -557,6 +606,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Camera'
 
     ChannelToImageMgr = mari.actions.create('Quick Unproject Channel', 'mari.customScripts.unproject_channel_to_imageman()')
+    mari.actions.addToSet('RequiresProject',ChannelToImageMgr)
+
     mari.menus.addAction(ChannelToImageMgr, script_menu_path)
     mari.menus.addAction(ChannelToImageMgr, UI_path,'Camera Left')
 
@@ -573,6 +624,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/Camera'
 
     LayerToImageMgr = mari.actions.create('Quick Unproject Layer', 'mari.customScripts.unproject_layer_to_imageman()')
+    mari.actions.addToSet('RequiresProject',LayerToImageMgr)
+
     mari.menus.addAction(LayerToImageMgr, UI_path,'Camera Left')
     mari.menus.addAction(LayerToImageMgr, script_menu_path)
 
@@ -601,6 +654,8 @@ def createToolsMenu():
     script_menu_path = 'MainWindow/Scripts/View'
 
     screenshotChannels = mari.actions.create('Screenshot All Channels','mari.customScripts.screenshot_all_channels()')
+    mari.actions.addToSet('RequiresProject',screenshotChannels)
+
     mari.menus.addAction(screenshotChannels, UI_path, 'Screenshot Settings')
     mari.menus.addAction(screenshotChannels, script_menu_path)
 
@@ -620,6 +675,8 @@ def createToolsMenu():
 
     action_viewportDisable = mari.actions.create("Pause Viewport Update", "mari.customScripts.disableViewport()")
     action_viewportDisable.setCheckable(True)
+    mari.actions.addToSet('RequiresProject',action_viewportDisable)
+
 
     mari.menus.addAction(action_viewportDisable, script_menu_path)
     mari.menus.addAction(action_viewportDisable, UI_path, 'Toggle Wireframe')
@@ -662,6 +719,9 @@ def createToolsMenu():
         "Sync Object Shaders", "mari.customScripts.setAllObjectsToShader()"
         )
 
+    mari.actions.addToSet('RequiresProject',syncObjectShaders)
+
+
     syncObjectShaders.setStatusTip('Sync your Shader Selection across all Objects')
     syncObjectShaders.setToolTip('Sync Object Shader Selection')
     syncObjectShaders.setWhatsThis('Sync Object Shader Selection between Objects')
@@ -683,7 +743,10 @@ def createToolsMenu():
 
     UI_path_B = 'MriGeometrySelectionGroup/Panel'
     script_menu_path = 'MainWindow/Scripts/Selection Groups'
+
     matIdFromGroup = mari.actions.create("MaterialID from Selection Groups", "mari.customScripts.matIDFromGroup()")
+    mari.actions.addToSet('RequiresProject',matIdFromGroup)
+
 
     matIdFromGroup.setStatusTip('Create a MaterialID Channel from Selection Groups')
     matIdFromGroup.setToolTip('Create a MaterialID Channel from Selection Groups')
@@ -706,28 +769,19 @@ def createToolsMenu():
     UI_path = 'MriImageManager/ItemContext'
     script_menu_path = 'MainWindow/Scripts/Image Manager'
 
-    exportUVMask = mari.actions.create ('Export Selection', 'mari.customScripts.exportImageManager()')
-    mari.menus.addAction(exportUVMask, UI_path)
-    mari.menus.addAction(exportUVMask, script_menu_path)
+    exportImageMan = mari.actions.create ('Export Selection', 'mari.customScripts.exportImageManager()')
+    mari.actions.addToSet('RequiresProject',exportImageMan)
+
+    mari.menus.addAction(exportImageMan, UI_path)
+    mari.menus.addAction(exportImageMan, script_menu_path)
 
     icon_filename = 'ExtractImage.png'
     icon_path = mari.resources.path(mari.resources.ICONS) + os.sep +  icon_filename
-    exportUVMask.setIconPath(icon_path)
+    exportImageMan.setIconPath(icon_path)
 
     ###  Menu Separators ###
 
     mari.menus.addSeparator(UI_path,'Export Selection')
-
-
-######################################################################
-# Shelves
-######################################################################
-
-    #  Export selected Shelves
-
-    UI_path = '/Mari/Palettes/Shelf'
-    script_menu_path = 'MainWindow/Scripts/Shelves'
-
 
 
 
@@ -751,3 +805,19 @@ def createToolsMenu():
     ###  Menu Separators ###
 
     mari.menus.addSeparator(UI_path,'Release Notes')
+
+
+
+
+######################################################################
+# DISABLE ELEMENTS WHEN NO PROJECT IS OPEN
+######################################################################
+
+
+    if mari.projects.current() is None:
+        mari.actions.disableSet('RequiresProject')
+    else:
+        mari.actions.enableSet('RequiresProject')
+
+    mari.utils.connect(mari.projects.opened, lambda: mari.actions.enableSet('RequiresProject'))
+    mari.utils.connect(mari.projects.closed, lambda: mari.actions.disableSet('RequiresProject'))

--- a/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
+++ b/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
@@ -393,7 +393,7 @@ def createToolsMenu():
 
     UI_path = 'MainWindow/&Layers/' + u'Pin'
 
-    quickPinLayer = mari.actions.create('Quick Pin Layer(s)', None)
+    quickPinLayer = mari.actions.create('Quick Pin Layer(s)', 'mari.customScripts.quickPin()')
     pinLayer = mari.actions.create('Pin Layer(s) to Collection', None)
     manageCollections = mari.actions.create('Manage Collections',None)
     empty = mari.actions.create('Do nothing',None)

--- a/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
+++ b/Scripts/ExtensionPack_3v01/Tools/tools_menu.py
@@ -389,6 +389,46 @@ def createToolsMenu():
 
     # --------------------------------------------------------------------
 
+    ### Pin Layers
+
+    UI_path = 'MainWindow/&Layers/' + u'Pin'
+
+    quickPinLayer = mari.actions.create('Quick Pin Layer(s)', None)
+    pinLayer = mari.actions.create('Pin Layer(s) to Collection', None)
+    manageCollections = mari.actions.create('Manage Collections',None)
+    empty = mari.actions.create('Do nothing',None)
+
+    # mari.menus.addSeparator(UI_path,'Remove Layers')
+
+    mari.menus.addAction(quickPinLayer,UI_path,'Cut')
+    mari.menus.addAction(pinLayer,UI_path)
+    mari.menus.addAction(manageCollections,UI_path)
+    mari.menus.addAction(empty,UI_path)
+    mari.menus.addSeparator(UI_path,'Do nothing')
+    mari.menus.removeAction(empty,UI_path)
+
+
+    icon_filename = 'Painting.png'
+    icon_path = mari.resources.path(mari.resources.ICONS) + os.sep +  icon_filename
+    quickPinLayer.setIconPath(icon_path)
+    pinLayer.setIconPath(icon_path)
+
+    icon_filename = 'Folder.png'
+    icon_path = mari.resources.path(mari.resources.ICONS) + os.sep +  icon_filename
+    manageCollections.setIconPath(icon_path)
+
+    UI_path = 'MainWindow/&Layers/' + u'Add Pinned Layer'
+    emptyQuick = mari.actions.create('No Layer pinned',None)
+    mari.menus.addAction(empty,UI_path,'Add Adjustment Layer')
+    UI_path_quick = 'MainWindow/&Layers/' + u'Add Pinned Layer/Quick Pins'
+    mari.menus.addAction(emptyQuick,UI_path_quick)
+    mari.menus.removeAction(empty,UI_path)
+
+
+
+    # --------------------------------------------------------------------
+
+
     ###  Toggle Layer Visbility ###
 
     UI_path = 'MainWindow/&Layers/' + u'Visibility + Lock'
@@ -677,6 +717,18 @@ def createToolsMenu():
     ###  Menu Separators ###
 
     mari.menus.addSeparator(UI_path,'Export Selection')
+
+
+######################################################################
+# Shelves
+######################################################################
+
+    #  Export selected Shelves
+
+    UI_path = '/Mari/Palettes/Shelf'
+    script_menu_path = 'MainWindow/Scripts/Shelves'
+
+
 
 
 ######################################################################


### PR DESCRIPTION
- Pause Viewport is now using a python function and no longer triggering another action
  It is also hooked directly to the viewport signal so it does not fall out of sync with the state of the  viewport

- Hotkeys for Extension Pack have been reworked:
  Hotkeys are now grouped in the Hotkey Editor and Actions are moved into their own category
  User Hotkey assignment is correctly set at the end of the tool load
  Default Hotkeys are no longer set no matter what but checking first if a user hotkey exists (and if the default hotkey is used elsewhere

- Pinned Layers
  A new sharing system was implemented (v0.5) to make sharing of layers easier.